### PR TITLE
refactor balance calculation and add self-transfer handling

### DIFF
--- a/src/main/java/seedu/duke/command/BalanceCommand.java
+++ b/src/main/java/seedu/duke/command/BalanceCommand.java
@@ -1,13 +1,10 @@
 package seedu.duke.command;
 
 import seedu.duke.exceptions.Exceptions;
-import seedu.duke.model.Block;
 import seedu.duke.model.Blockchain;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class BalanceCommand extends Command {
     private static final String HELP_DESCRIPTION = """
@@ -15,8 +12,6 @@ public class BalanceCommand extends Command {
             Displays the balance of wallet up to 8 decimal points
             """;
     private static final String NAME_ERROR = "Error: wallet name cannot be empty.";
-    private static final Pattern TRANSACTION_PATTERN =
-            Pattern.compile("^(.+?)\\s*->\\s*(.+?)\\s*:\\s*([+-]?\\d+(?:\\.\\d+)?)$");
 
     private final String walletName;
 
@@ -33,34 +28,9 @@ public class BalanceCommand extends Command {
         }
 
         String trimmedWalletName = walletName.trim();
-        BigDecimal balance = BigDecimal.ZERO;
-        for (int i = 0; i < blockchain.size(); i++) {
-            Block block = blockchain.getBlock(i);
-            for (String transaction : block.getTransactions()) {
-                balance = balance.add(getBalanceDelta(trimmedWalletName, transaction));
-            }
-        }
+        BigDecimal balance = blockchain.getPreciseBalance(trimmedWalletName);
 
         System.out.println("Balance of " + trimmedWalletName + ": " + formatBalance(balance));
-    }
-
-    private BigDecimal getBalanceDelta(String trimmedWalletName, String transaction) {
-        Matcher matcher = TRANSACTION_PATTERN.matcher(transaction);
-        if (!matcher.matches()) {
-            return BigDecimal.ZERO;
-        }
-
-        String sender = matcher.group(1).trim();
-        String receiver = matcher.group(2).trim();
-        BigDecimal amount = new BigDecimal(matcher.group(3));
-        BigDecimal delta = BigDecimal.ZERO;
-        if (sender.equalsIgnoreCase(trimmedWalletName)) {
-            delta = delta.subtract(amount);
-        }
-        if (receiver.equalsIgnoreCase(trimmedWalletName)) {
-            delta = delta.add(amount);
-        }
-        return delta;
     }
 
     private String formatBalance(BigDecimal balance) {

--- a/src/main/java/seedu/duke/model/Blockchain.java
+++ b/src/main/java/seedu/duke/model/Blockchain.java
@@ -1,12 +1,17 @@
 package seedu.duke.model;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class Blockchain {
     private static final String GENESIS_PREVIOUS_HASH = "0000000000000000";
+    private static final Pattern TRANSACTION_PATTERN =
+            Pattern.compile("^(.+?)\\s*->\\s*(.+?)\\s*:\\s*([+-]?\\d+(?:\\.\\d+)?)$");
 
     private final List<Block> blocks;
 
@@ -72,42 +77,36 @@ public class Blockchain {
     }
 
     public double getBalance(String walletName) {
-        double balance = 0.0;
+        return getPreciseBalance(walletName).doubleValue();
+    }
+
+    public BigDecimal getPreciseBalance(String walletName) {
+        String normalizedWalletName = walletName == null ? "" : walletName.trim();
+        BigDecimal balance = BigDecimal.ZERO;
         for (Block block : blocks) {
             for (String transaction : block.getTransactions()) {
-                balance += parseTransactionAmount(walletName, transaction);
+                balance = balance.add(parseTransactionAmount(normalizedWalletName, transaction));
             }
         }
         return balance;
     }
 
-    private double parseTransactionAmount(String walletName, String transaction) {
-        // Expected format: "sender -> receiver : amount"
-        String[] parts = transaction.split(" -> ");
-        if (parts.length != 2) {
-            return 0.0;
-        }
-        String sender = parts[0].trim();
-        String rest = parts[1];
-        String[] receiverAmount = rest.split(" : ");
-        if (receiverAmount.length != 2) {
-            return 0.0;
-        }
-        String receiver = receiverAmount[0].trim();
-        String amountStr = receiverAmount[1].trim();
-
-        double amount;
-        try {
-            amount = Double.parseDouble(amountStr);
-        } catch (NumberFormatException e) {
-            return 0.0;
+    private BigDecimal parseTransactionAmount(String walletName, String transaction) {
+        Matcher matcher = TRANSACTION_PATTERN.matcher(transaction);
+        if (!matcher.matches()) {
+            return BigDecimal.ZERO;
         }
 
-        if (walletName.equalsIgnoreCase(receiver)) {
-            return amount;
-        } else if (walletName.equalsIgnoreCase(sender)) {
-            return -amount;
+        String sender = matcher.group(1).trim();
+        String receiver = matcher.group(2).trim();
+        BigDecimal amount = new BigDecimal(matcher.group(3));
+        BigDecimal delta = BigDecimal.ZERO;
+        if (sender.equalsIgnoreCase(walletName)) {
+            delta = delta.subtract(amount);
         }
-        return 0.0;
+        if (receiver.equalsIgnoreCase(walletName)) {
+            delta = delta.add(amount);
+        }
+        return delta;
     }
 }

--- a/src/test/java/seedu/duke/command/BalanceCommandTest.java
+++ b/src/test/java/seedu/duke/command/BalanceCommandTest.java
@@ -45,6 +45,26 @@ class BalanceCommandTest {
     }
 
     @Test
+    void execute_selfTransfer_keepsNetZeroBalance() {
+        Blockchain blockchain = new Blockchain(List.of(
+                new Block(
+                        0,
+                        LocalDateTime.of(2026, 2, 12, 14, 30, 21),
+                        "0000000000000000",
+                        List.of("Genesis Block")),
+                new Block(
+                        1,
+                        LocalDateTime.of(2026, 2, 12, 14, 35, 2),
+                        "prev-hash",
+                        List.of("alice -> alice : 5"))));
+        BalanceCommand command = new BalanceCommand("alice");
+
+        String output = runCommand(command, blockchain);
+
+        assertEquals("Balance of alice: 0.00000000" + System.lineSeparator(), output);
+    }
+
+    @Test
     void execute_blankWalletName_printsError() {
         Blockchain blockchain = Blockchain.createDefault();
         BalanceCommand command = new BalanceCommand("   ");

--- a/src/test/java/seedu/duke/command/SendCommandTest.java
+++ b/src/test/java/seedu/duke/command/SendCommandTest.java
@@ -4,11 +4,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import seedu.duke.exceptions.Exceptions;
+import seedu.duke.model.Block;
 import seedu.duke.model.Blockchain;
 import seedu.duke.model.WalletManager;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.time.LocalDateTime;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -69,6 +72,27 @@ class SendCommandTest {
 
         Exceptions exception = assertThrows(Exceptions.class, () -> command.execute(blockchain));
         assertEquals("Error: Invalid send format. Use: send w/WALLET to/ADDR amt/AMT", exception.getMessage());
+    }
+
+    @Test
+    void execute_selfTransferDoesNotIncreaseSpendableBalance_throwsException() {
+        Blockchain blockchain = new Blockchain(List.of(
+                new Block(
+                        0,
+                        LocalDateTime.of(2026, 2, 12, 14, 30, 21),
+                        "0000000000000000",
+                        List.of("Genesis Block")),
+                new Block(
+                        1,
+                        LocalDateTime.of(2026, 2, 12, 14, 35, 2),
+                        "prev-hash",
+                        List.of("alice -> alice : 5"))));
+        WalletManager walletManager = new WalletManager();
+        walletManager.createWallet("alice");
+        SendCommand command = new SendCommand("w/alice to/bob amt/1", walletManager);
+
+        Exceptions exception = assertThrows(Exceptions.class, () -> command.execute(blockchain));
+        assertEquals("Error: Insufficient balance.", exception.getMessage());
     }
 
     private String runCommand(Command command, Blockchain blockchain) {


### PR DESCRIPTION
- replace balance summation logic with `Blockchain.getPreciseBalance`
- move transaction parsing to `Blockchain` and centralize logic
- update `BalanceCommand` to use new method for wallet balance retrieval
- add tests for self-transfer scenarios to ensure correct balance behavior
- adjust error handling in `SendCommand` for self-transfers with no balance increase