### PR TITLE
update CreateCommand to enforce "n/" prefix and improve argument parsing

### DIFF
--- a/src/main/java/seedu/duke/command/CreateCommand.java
+++ b/src/main/java/seedu/duke/command/CreateCommand.java
@@ -7,24 +7,26 @@ import seedu.duke.model.WalletManager;
 
 public class CreateCommand extends Command {
     private static final String HELP_DESCRIPTION = """
-            format: create NAME
+            format: create n/NAME
             Creates a wallet called NAME
             """;
   
     private static final String NAME_ERROR = "Error: wallet name cannot be empty.";
     private static final String DUPLICATE_ERROR = "Error: wallet name already exists.";
+    private static final String INVALID_FORMAT_ERROR = "Error: Invalid create format. Use: create n/WALLET_NAME";
 
-    private final String walletName;
+    private final String arguments;
     private final WalletManager walletManager;
 
-    public CreateCommand(String walletName, WalletManager walletManager) {
+    public CreateCommand(String arguments, WalletManager walletManager) {
         super(HELP_DESCRIPTION);
-        this.walletName = walletName;
+        this.arguments = arguments;
         this.walletManager = walletManager;
     }
 
     @Override
     public void execute(String description, Blockchain blockchain) throws Exceptions {
+        String walletName = parseArguments(arguments);
         if (walletName == null || walletName.isBlank()) {
             throw new Exceptions(NAME_ERROR);
         }
@@ -36,5 +38,18 @@ public class CreateCommand extends Command {
 
         Wallet wallet = walletManager.createWallet(trimmedWalletName);
         System.out.println("Wallet created: " + wallet.getName());
+    }
+
+    private String parseArguments(String args) throws Exceptions {
+        if (args == null || args.isBlank()) {
+            throw new Exceptions(NAME_ERROR);
+        }
+
+        String trimmedArgs = args.trim();
+        if (!trimmedArgs.startsWith("n/")) {
+            throw new Exceptions(INVALID_FORMAT_ERROR);
+        }
+
+        return trimmedArgs.substring(2).trim();
     }
 }

--- a/src/test/java/seedu/duke/command/CreateCommandTest.java
+++ b/src/test/java/seedu/duke/command/CreateCommandTest.java
@@ -17,7 +17,7 @@ class CreateCommandTest {
     void execute_validName_createsWallet() {
         Blockchain blockchain = Blockchain.createDefault();
         WalletManager walletManager = new WalletManager();
-        CreateCommand command = new CreateCommand("alice", walletManager);
+        CreateCommand command = new CreateCommand("n/alice", walletManager);
 
         String output = runCommand(command, blockchain);
 
@@ -30,7 +30,7 @@ class CreateCommandTest {
     void execute_blankName_throwsException() {
         Blockchain blockchain = Blockchain.createDefault();
         WalletManager walletManager = new WalletManager();
-        CreateCommand command = new CreateCommand("   ", walletManager);
+        CreateCommand command = new CreateCommand("n/   ", walletManager);
 
         Exceptions exception = assertThrows(Exceptions.class, () -> command.execute(blockchain));
         assertEquals("Error: wallet name cannot be empty.", exception.getMessage());
@@ -42,11 +42,22 @@ class CreateCommandTest {
         Blockchain blockchain = Blockchain.createDefault();
         WalletManager walletManager = new WalletManager();
         walletManager.createWallet("alice");
-        CreateCommand command = new CreateCommand("alice", walletManager);
+        CreateCommand command = new CreateCommand("n/alice", walletManager);
 
         Exceptions exception = assertThrows(Exceptions.class, () -> command.execute(blockchain));
         assertEquals("Error: wallet name already exists.", exception.getMessage());
         assertEquals(1, walletManager.getWallets().size());
+    }
+
+    @Test
+    void execute_missingNamePrefix_throwsException() {
+        Blockchain blockchain = Blockchain.createDefault();
+        WalletManager walletManager = new WalletManager();
+        CreateCommand command = new CreateCommand("alice", walletManager);
+
+        Exceptions exception = assertThrows(Exceptions.class, () -> command.execute(blockchain));
+        assertEquals("Error: Invalid create format. Use: create n/WALLET_NAME", exception.getMessage());
+        assertEquals(0, walletManager.getWallets().size());
     }
 
     private String runCommand(Command command, Blockchain blockchain) {

--- a/text-ui-test/input.txt
+++ b/text-ui-test/input.txt
@@ -1,5 +1,5 @@
-create alice
-create bob
+create n/alice
+create n/bob
 send w/bob to/alice amt/5
 send w/alice to/bob amt/1
 send w/nonexistent to/alice amt/1


### PR DESCRIPTION
- modify CreateCommand to require "n/" prefix for wallet names
- add argument validation and parsing logic to enforce correct format
- update tests and text UI inputs to align with new specification