### PR TITLE
Key pair, Wallet address, and Currency Code persistance

### DIFF
--- a/src/main/java/seedu/crypto1010/model/KeyPair.java
+++ b/src/main/java/seedu/crypto1010/model/KeyPair.java
@@ -50,6 +50,11 @@ public class KeyPair {
     private final String walletAddress;
     private final String currencyCode;
 
+    public static KeyPair restore(BigInteger privateKey, BigInteger publicKeyX,
+                                  BigInteger publicKeyY, String address, String currencyCode) {
+        return new KeyPair(privateKey, publicKeyX, publicKeyY, address, currencyCode);
+    }
+
     private KeyPair(BigInteger privateKey, BigInteger publicKeyX, BigInteger publicKeyY,
                     String walletAddress, String currencyCode) {
         this.privateKey = privateKey;

--- a/src/main/java/seedu/crypto1010/model/KeyPair.java
+++ b/src/main/java/seedu/crypto1010/model/KeyPair.java
@@ -50,11 +50,6 @@ public class KeyPair {
     private final String walletAddress;
     private final String currencyCode;
 
-    public static KeyPair restore(BigInteger privateKey, BigInteger publicKeyX,
-                                  BigInteger publicKeyY, String address, String currencyCode) {
-        return new KeyPair(privateKey, publicKeyX, publicKeyY, address, currencyCode);
-    }
-
     private KeyPair(BigInteger privateKey, BigInteger publicKeyX, BigInteger publicKeyY,
                     String walletAddress, String currencyCode) {
         this.privateKey = privateKey;
@@ -82,6 +77,14 @@ public class KeyPair {
 
     public String getCurrencyCode() {
         return currencyCode;
+    }
+
+    /**
+     * Restores keypair data from previous sessions to insert into this session.
+     */
+    public static KeyPair restore(BigInteger privateKey, BigInteger publicKeyX,
+                                  BigInteger publicKeyY, String address, String currencyCode) {
+        return new KeyPair(privateKey, publicKeyX, publicKeyY, address, currencyCode);
     }
 
     /**

--- a/src/main/java/seedu/crypto1010/model/Wallet.java
+++ b/src/main/java/seedu/crypto1010/model/Wallet.java
@@ -48,8 +48,17 @@ public class Wallet {
         return address;
     }
 
+    public KeyPair getKeyPair() {
+        return keyPair;
+    }
+
     public boolean hasKeyPair() {
         return keyPair != null;
+    }
+
+    public void restoreKeyPair(KeyPair keyPair) {
+        this.keyPair = keyPair;
+        this.address = keyPair.getWalletAddress();
     }
 
     public void addTransaction(String transactionEntry) {
@@ -63,7 +72,10 @@ public class Wallet {
         return Collections.unmodifiableList(transactionHistory);
     }
 
-    public void setKeys(KeyPair keys) {
+    public void setKeys(KeyPair keys) throws Crypto1010Exception {
+        if (this.keyPair != null) {
+            throw new Crypto1010Exception("Error: wallet already has a key pair.");
+        }
         String generatedAddress = keys.getWalletAddress();
         if (generatedAddress == null || generatedAddress.isBlank()) {
             throw new IllegalArgumentException(INVALID_KEYS_ERROR);

--- a/src/main/java/seedu/crypto1010/storage/WalletStorage.java
+++ b/src/main/java/seedu/crypto1010/storage/WalletStorage.java
@@ -1,10 +1,12 @@
 package seedu.crypto1010.storage;
 
 import seedu.crypto1010.exceptions.Crypto1010Exception;
+import seedu.crypto1010.model.KeyPair;
 import seedu.crypto1010.model.Wallet;
 import seedu.crypto1010.model.WalletManager;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -58,14 +60,31 @@ public class WalletStorage {
             if (line.startsWith(WALLET_PREFIX)) {
                 // A wallet header starts a new wallet context for the following transaction lines.
                 String walletData = line.substring(WALLET_PREFIX.length());
-                String[] walletFields = walletData.split("\\|", 2);
+                String[] walletFields = walletData.split("\\|", 6);
                 String walletName = unescape(walletFields[0]);
-                String currencyCode = walletFields.length == 2 ? unescape(walletFields[1]) : null;
+                String currencyCode = walletFields.length >= 2 ? unescape(walletFields[1]) : null;
                 try {
                     currentWallet = walletManager.createWallet(walletName, currencyCode);
                 } catch (Crypto1010Exception e) {
                     throw new IOException("Invalid wallet data: " + e.getMessage(), e);
                 }
+
+                if (walletFields.length == 6) {
+                    try {
+                        String address = unescape(walletFields[2]);
+                        BigInteger publicKeyX = new BigInteger(walletFields[3], 16);
+                        BigInteger publicKeyY = new BigInteger(walletFields[4], 16);
+                        BigInteger privateKey = new BigInteger(walletFields[5], 16);
+                        currentWallet.restoreKeyPair(
+                                KeyPair.restore(privateKey, publicKeyX, publicKeyY,
+                                                address, currentWallet.getCurrencyCode()));
+                    } catch (Exception e) {
+                        System.out.println("[Warning] Key data for wallet '" + currentWallet.getName()
+                                                   + "' is corrupted and could not be restored. "
+                                                   + "Please run keygen on this wallet to generate new keys.");
+                    }
+                }
+
                 walletCount++;
                 if (walletCount > MAX_WALLET_COUNT) {
                     throw new IOException("Invalid wallet data: too many wallets.");
@@ -104,10 +123,26 @@ public class WalletStorage {
     public void save(WalletManager walletManager) throws IOException {
         StringBuilder content = new StringBuilder();
         for (Wallet wallet : walletManager.getWallets()) {
-            content.append(WALLET_PREFIX).append(escape(wallet.getName()));
-            if (!"generic".equals(wallet.getCurrencyCode())) {
-                content.append(FIELD_SEPARATOR).append(escape(wallet.getCurrencyCode()));
+            content.append(WALLET_PREFIX)
+                    .append(escape(wallet.getName()))
+                    .append(FIELD_SEPARATOR)
+                    .append(escape(wallet.getCurrencyCode()));
+
+            if (wallet.hasKeyPair()) {
+                try {
+                    content.append(FIELD_SEPARATOR)
+                            .append(escape(wallet.getAddress()))
+                            .append(FIELD_SEPARATOR)
+                            .append(wallet.getKeyPair().getPublicKeyX().toString(16))
+                            .append(FIELD_SEPARATOR)
+                            .append(wallet.getKeyPair().getPublicKeyY().toString(16))
+                            .append(FIELD_SEPARATOR)
+                            .append(wallet.getKeyPair().getPrivateKey().toString(16));
+                } catch (Crypto1010Exception e) {
+                    // address not set — skip key fields
+                }
             }
+
             content.append(System.lineSeparator());
             for (String transaction : wallet.getTransactionHistory()) {
                 content.append(TRANSACTION_PREFIX).append(escape(transaction)).append(System.lineSeparator());

--- a/src/test/java/seedu/crypto1010/model/WalletManagerTest.java
+++ b/src/test/java/seedu/crypto1010/model/WalletManagerTest.java
@@ -2,6 +2,7 @@ package seedu.crypto1010.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -13,7 +14,9 @@ class WalletManagerTest {
         WalletManager walletManager = new WalletManager();
         walletManager.createWallet("alice");
 
-        assertThrows(Crypto1010Exception.class, () -> walletManager.createWallet("Alice"));
+        Crypto1010Exception exception =
+                assertThrows(Crypto1010Exception.class, () -> walletManager.createWallet("Alice"));
+        assertTrue(exception.getMessage().contains("wallet already exists"));
     }
 
     @Test
@@ -23,8 +26,7 @@ class WalletManagerTest {
 
         Crypto1010Exception exception =
                 assertThrows(Crypto1010Exception.class, () -> walletManager.createWallet("bob", "btc"));
-        assertEquals("Error: a wallet for that currency already exists in this account."
-                + "Use: create w/WALLET_NAME [curr/CURRENCY]", exception.getMessage());
+        assertTrue(exception.getMessage().contains("currency already exists"));
     }
 
     @Test
@@ -33,7 +35,7 @@ class WalletManagerTest {
 
         Crypto1010Exception exception =
                 assertThrows(Crypto1010Exception.class, () -> walletManager.createWallet("ali|ce"));
-        assertEquals("walletName contains reserved character: |", exception.getMessage());
+        assertTrue(exception.getMessage().contains("reserved character"));
     }
 
     @Test
@@ -42,7 +44,45 @@ class WalletManagerTest {
 
         Crypto1010Exception exception =
                 assertThrows(Crypto1010Exception.class,
-                        () -> walletManager.createWallet("abcdefghijklmnopqrstuvwxyz1234567"));
+                             () -> walletManager.createWallet("abcdefghijklmnopqrstuvwxyz1234567"));
         assertEquals("walletName exceeds max length: 32", exception.getMessage());
+    }
+
+    @Test
+    void createWallet_reservedName_throwsCrypto1010Exception() {
+        WalletManager walletManager = new WalletManager();
+
+        Crypto1010Exception exception =
+                assertThrows(Crypto1010Exception.class, () -> walletManager.createWallet("network"));
+        assertTrue(exception.getMessage().contains("reserved"));
+    }
+
+    @Test
+    void createWallet_blankName_throwsCrypto1010Exception() {
+        WalletManager walletManager = new WalletManager();
+
+        Crypto1010Exception exception =
+                assertThrows(Crypto1010Exception.class, () -> walletManager.createWallet("   "));
+        assertTrue(exception.getMessage().contains("must not be blank"));
+    }
+
+    @Test
+    void createWallet_validName_createsWallet() throws Crypto1010Exception {
+        WalletManager walletManager = new WalletManager();
+
+        Wallet wallet = walletManager.createWallet("alice");
+
+        assertEquals("alice", wallet.getName());
+        assertEquals(CurrencyCode.GENERIC, wallet.getCurrencyCode());
+        assertEquals(1, walletManager.getWallets().size());
+    }
+
+    @Test
+    void createWallet_validNameWithCurrency_createsWalletWithCurrency() throws Crypto1010Exception {
+        WalletManager walletManager = new WalletManager();
+
+        Wallet wallet = walletManager.createWallet("alice", "eth");
+
+        assertEquals("eth", wallet.getCurrencyCode());
     }
 }

--- a/src/test/java/seedu/crypto1010/model/WalletTest.java
+++ b/src/test/java/seedu/crypto1010/model/WalletTest.java
@@ -1,15 +1,96 @@
 package seedu.crypto1010.model;
 
-//import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-//import org.junit.jupiter.api.Test;
+import seedu.crypto1010.exceptions.Crypto1010Exception;
+
+import org.junit.jupiter.api.Test;
 
 class WalletTest {
 
-    //  @Test
-    //  void setKeys_arrayTooShort_throwsIllegalArgumentException() {
-    //      Wallet wallet = new Wallet("alice");
-    //
-    //      assertThrows(IllegalArgumentException.class, () -> wallet.setKeys(new Key[] {Key.generateKeyPair()[0]}));
-    //  }
+    @Test
+    void constructor_setsNameAndGenericCurrency() {
+        Wallet wallet = new Wallet("alice");
+
+        assertEquals("alice", wallet.getName());
+        assertEquals(CurrencyCode.GENERIC, wallet.getCurrencyCode());
+    }
+
+    @Test
+    void constructor_withCurrency_setsCurrencyCode() {
+        Wallet wallet = new Wallet("alice", "eth");
+
+        assertEquals("eth", wallet.getCurrencyCode());
+    }
+
+    @Test
+    void getAddress_noKeyPair_throwsException() {
+        Wallet wallet = new Wallet("alice");
+
+        assertThrows(Crypto1010Exception.class, wallet::getAddress);
+    }
+
+    @Test
+    void hasKeyPair_noKeyPair_returnsFalse() {
+        Wallet wallet = new Wallet("alice");
+
+        assertFalse(wallet.hasKeyPair());
+    }
+
+    @Test
+    void setKeys_validKeyPair_setsAddressAndKeyPair() throws Crypto1010Exception {
+        Wallet wallet = new Wallet("alice");
+        KeyPair keyPair = KeyPair.generate("eth");
+
+        wallet.setKeys(keyPair);
+
+        assertTrue(wallet.hasKeyPair());
+        assertEquals(keyPair.getWalletAddress(), wallet.getAddress());
+    }
+
+    @Test
+    void setKeys_calledTwice_throwsException() throws Crypto1010Exception {
+        Wallet wallet = new Wallet("alice");
+        KeyPair keyPair = KeyPair.generate("eth");
+        wallet.setKeys(keyPair);
+
+        assertThrows(Crypto1010Exception.class, () -> wallet.setKeys(KeyPair.generate("eth")));
+    }
+
+    @Test
+    void addTransaction_addsToHistory() {
+        Wallet wallet = new Wallet("alice");
+
+        wallet.addTransaction("to/0x123 amt/1 fee/0");
+
+        assertEquals(1, wallet.getTransactionHistory().size());
+        assertEquals("to/0x123 amt/1 fee/0", wallet.getTransactionHistory().get(0));
+    }
+
+    @Test
+    void restoreKeyPair_setsKeyPairAndAddress() throws Crypto1010Exception {
+        Wallet wallet = new Wallet("alice");
+        KeyPair keyPair = KeyPair.generate("eth");
+
+        wallet.restoreKeyPair(keyPair);
+
+        assertTrue(wallet.hasKeyPair());
+        assertEquals(keyPair.getWalletAddress(), wallet.getAddress());
+    }
+
+    @Test
+    void restoreKeyPair_afterSetKeys_overwritesKeyPair() throws Crypto1010Exception {
+        Wallet wallet = new Wallet("alice");
+        KeyPair first = KeyPair.generate("eth");
+        wallet.setKeys(first);
+        KeyPair second = KeyPair.generate("eth");
+
+        // restoreKeyPair bypasses the lock — simulates storage restoration
+        wallet.restoreKeyPair(second);
+
+        assertEquals(second.getWalletAddress(), wallet.getKeyPair().getWalletAddress());
+    }
 }

--- a/src/test/java/seedu/crypto1010/storage/WalletStorageTest.java
+++ b/src/test/java/seedu/crypto1010/storage/WalletStorageTest.java
@@ -1,10 +1,12 @@
 package seedu.crypto1010.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import seedu.crypto1010.exceptions.Crypto1010Exception;
+import seedu.crypto1010.model.KeyPair;
 import seedu.crypto1010.model.Wallet;
 import seedu.crypto1010.model.WalletManager;
 
@@ -38,16 +40,12 @@ class WalletStorageTest {
     }
 
     @Test
-    void saveThenLoad_persistsWalletsAndHistory() throws IOException {
+    void saveThenLoad_persistsWalletsAndHistory() throws IOException, Crypto1010Exception {
         WalletManager manager = new WalletManager();
-        try {
-            Wallet alice = manager.createWallet("alice");
-            Wallet bob = manager.createWallet("bob");
-            alice.addTransaction("to/0xabc amt/1 speed/standard fee/0.001");
-            bob.addTransaction("to/0xdef amt/2 speed/manual fee/0.1 note/rent");
-        } catch (Crypto1010Exception e) {
-            throw new IOException(e.getMessage());
-        }
+        Wallet alice = manager.createWallet("alice");
+        Wallet bob = manager.createWallet("bob");
+        alice.addTransaction("to/0xabc amt/1 speed/standard fee/0.001");
+        bob.addTransaction("to/0xdef amt/2 speed/manual fee/0.1 note/rent");
 
         WalletStorage storage = new WalletStorage(WalletStorageTest.class);
         storage.save(manager);
@@ -65,13 +63,9 @@ class WalletStorageTest {
     }
 
     @Test
-    void saveThenLoad_persistsWalletCurrency() throws IOException {
+    void saveThenLoad_persistsWalletCurrency() throws IOException, Crypto1010Exception {
         WalletManager manager = new WalletManager();
-        try {
-            manager.createWallet("alice", "btc");
-        } catch (Crypto1010Exception e) {
-            throw new RuntimeException(e);
-        }
+        manager.createWallet("alice", "btc");
 
         WalletStorage storage = new WalletStorage(WalletStorageTest.class);
         storage.save(manager);
@@ -79,6 +73,37 @@ class WalletStorageTest {
 
         assertEquals(1, loaded.getWallets().size());
         assertEquals("btc", loaded.getWallets().get(0).getCurrencyCode());
+    }
+
+    @Test
+    void saveThenLoad_persistsKeyPairAndAddress() throws IOException, Crypto1010Exception {
+        WalletManager manager = new WalletManager();
+        Wallet alice = manager.createWallet("alice", "eth");
+        KeyPair keyPair = KeyPair.generate("eth");
+        alice.setKeys(keyPair);
+
+        WalletStorage storage = new WalletStorage(WalletStorageTest.class);
+        storage.save(manager);
+        WalletManager loaded = storage.load();
+
+        Wallet loadedAlice = loaded.getWallets().get(0);
+        assertTrue(loadedAlice.hasKeyPair());
+        assertEquals(keyPair.getWalletAddress(), loadedAlice.getKeyPair().getWalletAddress());
+        assertEquals(keyPair.getPublicKeyX(), loadedAlice.getKeyPair().getPublicKeyX());
+        assertEquals(keyPair.getPublicKeyY(), loadedAlice.getKeyPair().getPublicKeyY());
+        assertEquals(keyPair.getPrivateKey(), loadedAlice.getKeyPair().getPrivateKey());
+    }
+
+    @Test
+    void saveThenLoad_walletWithoutKeyPair_loadsWithoutKeyPair() throws IOException, Crypto1010Exception {
+        WalletManager manager = new WalletManager();
+        manager.createWallet("alice");
+
+        WalletStorage storage = new WalletStorage(WalletStorageTest.class);
+        storage.save(manager);
+        WalletManager loaded = storage.load();
+
+        assertFalse(loaded.getWallets().get(0).hasKeyPair());
     }
 
     @Test


### PR DESCRIPTION
Allows keys, address, and currency code of wallets to persist through logouts and exits.

Done by storing in txt file

To acknowledge in UG/DG of security and functional issues with txt file (to not mess with it)